### PR TITLE
Fixed API parameter (from query parameter to path parameter)

### DIFF
--- a/app/src/controllers/RoutineExerciseController.js
+++ b/app/src/controllers/RoutineExerciseController.js
@@ -8,7 +8,7 @@ const API_ROUTE = URL + TABLE;
 
 const getExercisesFromRoutine = async (routine_id) => {
   try {
-    const response = await axios.get(`${API_ROUTE}/?routine_id=${routine_id}`);
+    const response = await axios.get(`${API_ROUTE}/routine/${routine_id}`);
     const data = await response.data;
     const routineExercises = await data.data.map(
       (exercise) =>


### PR DESCRIPTION
Fixed API parameter as below because the corresponding API is using path parameter, not query parameter. However, this is the point that should be confirmed. However, this point needs to be checked for rules as a project again.
    
![image](https://github.com/user-attachments/assets/20b16fe7-5f61-4863-8c10-f35a2039f4a7)
    
const response = await axios.get(`${API_ROUTE}/?routine_id=${routine_id}`);
const response = await axios.get(`${API_ROUTE}/routine/${routine_id}`);