### PR TITLE
Bug fix: Streaks counting logic

### DIFF
--- a/app/src/components/GadgetStreaks.jsx
+++ b/app/src/components/GadgetStreaks.jsx
@@ -65,7 +65,9 @@ export const GadgetStreaks = ({ userInfo = null, history = [] }) => {
         }
         maxStreak = Math.max(maxStreak, ongoingStreak);
       } else {
-        currentStreakActive = false;
+        if (i !== 0) {
+          currentStreakActive = false;
+        }
         ongoingStreak = 0;
       }
     }


### PR DESCRIPTION
This pull request includes a small change to the `GadgetStreaks` component in `app/src/components/GadgetStreaks.jsx`. The change ensures that the `currentStreakActive` flag is only set to `false` when the index `i` is not zero.

* [`app/src/components/GadgetStreaks.jsx`](diffhunk://#diff-de59dbdfadfc9c45aef339df9078b312613b04c1f0f1eaca4cb5f3f8f3c63a14R68-R70): Added a condition to check if `i` is not zero before setting `currentStreakActive` to `false`.