### PR TITLE
Bugfix: displayed exercise order is not correct

### DIFF
--- a/app/src/components/RoutineExercisesList.jsx
+++ b/app/src/components/RoutineExercisesList.jsx
@@ -33,10 +33,20 @@ const modalStyle = {
 };
 
 export const RoutineExercisesList = ({ routineExercises = [], color = "primary.main" }) => {
+  const [orderedRoutineExercises, setOrderedRoutineExercises] = useState([]);
   const [selectedExercise, setselectedExercise] = useState('');
   const [exerciseDetail, setExerciseDetail] = useState({});
   const [showVideo, setShowVideo] = useState(false);
   const [showMore, setShowMore] = useState(false);
+
+  // Order exercises
+  useEffect(() => {
+    if (routineExercises.length === 0) return;
+
+    // Order routine exercises by specified order
+    const orderedRoutineExercises = [...routineExercises].sort((a, b) => a.order - b.order);
+    setOrderedRoutineExercises(orderedRoutineExercises);
+  }, []);
 
   // Load exercise detail data
   useEffect(() => {
@@ -65,7 +75,7 @@ export const RoutineExercisesList = ({ routineExercises = [], color = "primary.m
   return (
     <>
       <Box sx={{boxSizing: 'border-box', width: '100%', display: 'flex', flexDirection: 'column', gap: 2}}>
-        {routineExercises.map((exercise, index) => (
+        {orderedRoutineExercises.map((exercise, index) => (
           <Box
             key={index}
             onClick={() => handleOpenVideo(exercise)}


### PR DESCRIPTION
This pull request introduces changes to the `RoutineExercisesList` component to ensure that exercises are displayed in a specified order. The main updates include the addition of state to manage the ordered exercises and the use of a sorting function to order the exercises by their specified order.

Changes to `RoutineExercisesList` component:

* Added `orderedRoutineExercises` state and `useEffect` hook to sort `routineExercises` by their specified order and update the state accordingly (`app/src/components/RoutineExercisesList.jsx`, [app/src/components/RoutineExercisesList.jsxR36-R50](diffhunk://#diff-ac24834cfaa6c737f0616d9ccf8a88b9c69a9ad80c3b6d0f242ef80b6b94511bR36-R50)).
* Updated the rendering logic to use `orderedRoutineExercises` instead of `routineExercises` to display the exercises in the correct order (`app/src/components/RoutineExercisesList.jsx`, [app/src/components/RoutineExercisesList.jsxL68-R78](diffhunk://#diff-ac24834cfaa6c737f0616d9ccf8a88b9c69a9ad80c3b6d0f242ef80b6b94511bL68-R78)).