### PR TITLE
Added chips (muscle group, calorie, duration) to today's routine

### DIFF
--- a/app/src/components/CircularProgress.jsx
+++ b/app/src/components/CircularProgress.jsx
@@ -8,8 +8,8 @@ export const CircularProgress = () => {
             src={ GeneralLoading }
             alt="Loading"
             sx={{
-                width: "50%",
-                maxWidth: "450px",
+                width: "450px",
+                maxWidth: "100%",
             }}
         />
     );

--- a/app/src/components/GadgetRoutineOfToday.jsx
+++ b/app/src/components/GadgetRoutineOfToday.jsx
@@ -1,6 +1,6 @@
 import PropTypes from "prop-types";
 import { useState, memo, useEffect } from "react";
-import { Button, Typography, Box } from "@mui/material";
+import { Button, Typography, Box, Chip } from "@mui/material";
 import { CircularProgress } from "../components/CircularProgress.jsx";
 import { isSameDay, parseISO } from "date-fns";
 import { GadgetBase } from "./GadgetBase";
@@ -43,14 +43,6 @@ export const GadgetRoutineOfToday = memo(({ programRoutines = [] }) => {
   // Note: Now just showing the first routine, not considering the schedule. To be updated.
   return (
     <GadgetBase>
-      <Typography
-        variant="h6"
-        sx={{ width: "100%", textAlign: "left", fontWeight: "800" }}
-      >
-        Today&apos;s Routine
-      </Typography>
-
-
       {(loading) ? ( 
         <Box textAlign="center">
           <CircularProgress color="inherit" />
@@ -59,11 +51,76 @@ export const GadgetRoutineOfToday = memo(({ programRoutines = [] }) => {
           </Typography>
         </Box>
       ) : ( 
-        todayRoutine && todayRoutine.exercises.length > 0 ? (
+        todayRoutine && todayRoutine?.exercises?.length > 0 ? (
           <>
-            <Typography variant="h6" sx={{ width: "100%", textAlign: "left" }}>
-              {todayRoutine.name}
-            </Typography>
+            <Box 
+              sx={{ 
+                display: "flex", 
+                flexDirection: { xs: "column", sm: "row" },
+                justifyContent: "space-between",
+                gap: 2, 
+                width: "100%" 
+              }}
+            >
+              <Box sx={{ textAlign: "left" }}>
+                <Typography
+                  variant="h6"
+                  sx={{ width: "100%", textAlign: "left", fontWeight: "800", whiteSpace: "nowrap" }}
+                >
+                  Today&apos;s Routine
+                </Typography>
+                <Typography variant="h6" sx={{ width: "100%", textAlign: "left" }}>
+                  {todayRoutine.name}
+                </Typography>
+              </Box>
+              <Box 
+                sx= {{ 
+                  display: "flex", 
+                  flexDirection: "row",
+                  justifyContent: "flex-end", 
+                  alignSelf: "start",
+                  flexWrap: "wrap", 
+                  gap: 1,
+                }}
+              >
+                {todayRoutine.exercises && todayRoutine.exercises.length > 0 ? (
+                  <>
+                    {todayRoutine.duration > 0 ? (
+                      <Chip
+                        label={
+                          todayRoutine.duration < 60000
+                            ? `${Math.floor(todayRoutine.duration / 1000)} secs` // Display in seconds if less than 1 minute
+                            : `${Math.floor(todayRoutine.duration / 60000)} mins` +
+                              (Math.floor((todayRoutine.duration % 60000) / 1000) > 0
+                                ? ` ${Math.floor((todayRoutine.duration % 60000) / 1000)} secs`
+                                : "") // Only show seconds if > 0
+                        }
+                        variant="outlined"
+                      />
+                    ) : ""}
+                    <Chip
+                      label={`${todayRoutine.estimated_calories || "--"} Kcal`}
+                      variant="outlined"
+                    />
+                    {/* Collect all unique muscle group names from exercises */}
+                    {[...new Set(
+                      todayRoutine.exercises.flatMap((exercise) =>
+                        exercise.muscleGroups.map((mg) => mg.name)
+                      )
+                    )].map((muscleGroup, index) => (
+                      <Chip
+                        key={index}
+                        label={muscleGroup} // Display muscle group
+                        variant="outlined"
+                      />
+                    ))}
+                  </>
+                ) : (
+                  ""
+                )}
+              </Box>
+            </Box>
+
             {todayRoutine.exercises && todayRoutine.exercises.length > 0 ? (
               <RoutineExercisesList
                 routineExercises={todayRoutine.exercises}

--- a/app/src/components/GadgetSchedule.jsx
+++ b/app/src/components/GadgetSchedule.jsx
@@ -6,7 +6,7 @@ import { WeekPicker } from "./WeekPicker";
 import { RoutinesList } from "./RoutinesList";
 import { isWithinInterval, parseISO, startOfWeek, endOfWeek, addDays } from 'date-fns';
 import axiosClient from '../utils/axiosClient';
-import CircularProgress from '@mui/material/CircularProgress';
+import { CircularProgress } from "../components/CircularProgress.jsx";
 
 export const GadgetSchedule = memo(({ program = null, programRoutines = [] }) => {
   const today = new Date();

--- a/app/src/pages/RoutineSession.jsx
+++ b/app/src/pages/RoutineSession.jsx
@@ -1166,7 +1166,7 @@ export const RoutineSession = ({ title = "Routine Session" }) => {
               <>
                 {/* Calories */}
                 <Box sx={{minWidth: "85px"}}>
-                  <MetricCard title="kcal" value={calorie}/>
+                  <MetricCard title="Kcal" value={calorie}/>
                 </Box>
 
                 {/* Puase & Play */}


### PR DESCRIPTION
This pull request includes several updates to the `app/src/components` directory to improve the user interface and code consistency. The most important changes include updating the `CircularProgress` component, enhancing the `GadgetRoutineOfToday` component with additional UI elements, and ensuring consistent import statements.

Improvements to `CircularProgress` component:

* [`app/src/components/CircularProgress.jsx`](diffhunk://#diff-46da0c8440c70882d71a770e7b6f308b4a894b19d41580dcdc722ae1501a0c5cL11-R12): Adjusted the styling properties to set `width` to "450px" and `maxWidth` to "100%".

Enhancements to `GadgetRoutineOfToday` component:

* [`app/src/components/GadgetRoutineOfToday.jsx`](diffhunk://#diff-4b29cba9d59f34519e4261d589d2b7edcf031ea5db6db4ae0fcbac351b1e2be4L3-R3): Added `Chip` component to the imports.
* [`app/src/components/GadgetRoutineOfToday.jsx`](diffhunk://#diff-4b29cba9d59f34519e4261d589d2b7edcf031ea5db6db4ae0fcbac351b1e2be4L62-R123): Replaced the previous "Today's Routine" `Typography` element with a more flexible layout that includes `Chip` components to display routine details such as duration, estimated calories, and muscle groups.

Code consistency improvements:

* [`app/src/components/GadgetSchedule.jsx`](diffhunk://#diff-a74bfe382bf5684aa517fa3ac997e040c4b2d27d2d5fe9b3516c45fe34aa9beaL9-R9): Updated the import statement for `CircularProgress` to use the local `CircularProgress` component instead of the one from `@mui/material`.
* [`app/src/pages/RoutineSession.jsx`](diffhunk://#diff-9f9606d764bc39c5af06c19905b34313679db569d169723c1279bf6c0574fbc3L1169-R1169): Changed the title casing in the `MetricCard` component from "kcal" to "Kcal".