### PR TITLE
Send notifications for badge earning

### DIFF
--- a/app/src/components/Notifications.jsx
+++ b/app/src/components/Notifications.jsx
@@ -17,7 +17,7 @@ import { Button, Divider, Grid2 as Grid, Typography } from "@mui/material";
 import Toolbar from "@mui/material/Toolbar";
 import CloseIcon from "@mui/icons-material/Close";
 import filledNotificationIcon from "../assets/NotificationsFilled.png"; // Adjust path based on folder structure
-import NewbieNoMoreIcon from "../assets/Badge_NewbieNoMoreDark.svg";
+import NewbieNoMoreIcon from "../assets/Badge_NewbieNoMoreLight.svg";
 
 // Notifications Icon in Header
 function Notifications() {

--- a/app/src/components/WallOfFame.jsx
+++ b/app/src/components/WallOfFame.jsx
@@ -13,29 +13,7 @@ import { format } from "date-fns";
 import CloseIcon from "@mui/icons-material/Close";
 import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";
 import ArrowBackIosNewIcon from "@mui/icons-material/ArrowBackIosNew";
-import Badge1_Placeholder from "../assets/Badge_NewbieNoMoreDark.svg";
-import Badge2_Placeholder from "../assets/Badge_ConsistencyChampDark.svg";
-import Badge3_Placeholder from "../assets/Badge_CalorieCrusherDark.svg";
-import Badge4_Placeholder from "../assets/Badge_StreakStarDark.svg";
-import Badge1 from "../assets/Badge_NewbieNoMoreLight.svg";
-import Badge2 from "../assets/Badge_ConsistencyChampLight.svg";
-import Badge3 from "../assets/Badge_CalorieCrusherLight.svg";
-import Badge4 from "../assets/Badge_StreakStarLight.svg";
-
-const badgeMap = {
-  1: Badge1,
-  2: Badge2,
-  3: Badge3,
-  4: Badge4,
-};
-
-const badgeMap_Placeholder = {
-  1: Badge1_Placeholder,
-  2: Badge2_Placeholder,
-  3: Badge3_Placeholder,
-  4: Badge4_Placeholder,
-  placeholder: Badge1_Placeholder,
-};
+import {badgeMap, badgeMap_Placeholder } from "../utils/badgeMap.js";
 
 const modalStyle = {
   // Layout and positioning

--- a/app/src/pages/RoutineSession.jsx
+++ b/app/src/pages/RoutineSession.jsx
@@ -20,7 +20,6 @@ import {
 } from "@mediapipe/tasks-vision";
 import {
   Counter2,
-  // AngleMeter2,
   RestTime2,
   MetricCard,
   DemoExercise,
@@ -36,7 +35,7 @@ import { useAuth } from "../utils/AuthProvider.jsx";
 import theme from "../theme";
 import { supabase } from "../utils/supabaseClient.js";
 import axiosClient from "../utils/axiosClient";
-import { setPageTitle } from "../utils/utils";
+import { setPageTitle, sendNotification } from "../utils/utils";
 import { getUser } from "../controllers/UserController.js";
 import { getExercisesFromRoutine } from "../controllers/RoutineController.js";
 import {
@@ -931,9 +930,17 @@ export const RoutineSession = ({ title = "Routine Session" }) => {
           1,
           new Date().toISOString()
         );
-        console.log("Starter badge earned!", response);
+
+        // Send notification
+        sendNotification({
+          user_id: user.id,
+          title:'Congratulations! You have earned "Newbie No More" badge.',
+          message: 'You complete your first workout Routine and earned "Newbie No More".',
+          icon_id: 1,
+        });
+        console.log('"Newbie No More" badge earned!', response);
       } else {
-        console.log("Starter badge already earned.");
+        console.log('"Newbie No More" badge already earned.');
       }
 
       // Badge 2: The first program completion

--- a/app/src/utils/badgeMap.js
+++ b/app/src/utils/badgeMap.js
@@ -1,0 +1,23 @@
+import Badge1_Placeholder from "../assets/Badge_NewbieNoMoreDark.svg";
+import Badge2_Placeholder from "../assets/Badge_ConsistencyChampDark.svg";
+import Badge3_Placeholder from "../assets/Badge_CalorieCrusherDark.svg";
+import Badge4_Placeholder from "../assets/Badge_StreakStarDark.svg";
+import Badge1 from "../assets/Badge_NewbieNoMoreLight.svg";
+import Badge2 from "../assets/Badge_ConsistencyChampLight.svg";
+import Badge3 from "../assets/Badge_CalorieCrusherLight.svg";
+import Badge4 from "../assets/Badge_StreakStarLight.svg";
+
+export const badgeMap = {
+  1: Badge1,
+  2: Badge2,
+  3: Badge3,
+  4: Badge4,
+};
+
+export const badgeMap_Placeholder = {
+  1: Badge1_Placeholder,
+  2: Badge2_Placeholder,
+  3: Badge3_Placeholder,
+  4: Badge4_Placeholder,
+  placeholder: Badge1_Placeholder,
+};


### PR DESCRIPTION
This pull request includes several changes to improve the organization of badge assets and enhance the notification system in the application. The most important changes include refactoring the badge imports, updating the notification logic, and adding new utility functions.

### Refactoring badge imports:

* [`app/src/components/WallOfFame.jsx`](diffhunk://#diff-f0146c3b2f63cf14c505253b775e1d8ee40863c732257825e3e04ba238b68420L16-R16): Replaced individual badge imports with a consolidated import from a new `badgeMap.js` utility file.
* [`app/src/utils/badgeMap.js`](diffhunk://#diff-4a7961962efc6b6c08cd2c2d4d0701254e8270b1229b9d73da6902580ca22ae8R1-R23): Created a new utility file to manage badge imports and mappings.

### Enhancing notification system:

* [`app/src/pages/RoutineSession.jsx`](diffhunk://#diff-9f9606d764bc39c5af06c19905b34313679db569d169723c1279bf6c0574fbc3L934-R943): Added a new `sendNotification` function to send a notification when a user earns the "Newbie No More" badge. [[1]](diffhunk://#diff-9f9606d764bc39c5af06c19905b34313679db569d169723c1279bf6c0574fbc3L934-R943) [[2]](diffhunk://#diff-9f9606d764bc39c5af06c19905b34313679db569d169723c1279bf6c0574fbc3L39-R38)

### Minor changes:

* [`app/src/components/Notifications.jsx`](diffhunk://#diff-bf1b197f868bcbc4cd929211fcf7dc7b265eb9326023179152bab2fa0c45679cL20-R20): Updated the import path for the "Newbie No More" badge icon to use the light version.
* [`app/src/pages/RoutineSession.jsx`](diffhunk://#diff-9f9606d764bc39c5af06c19905b34313679db569d169723c1279bf6c0574fbc3L23): Removed a commented-out import for `AngleMeter2`.