### PR TITLE
Bugfix: cors origin checking logic

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -17,7 +17,7 @@ swaggerSetup(app);
 
 app.use(express.json());
 
-const allowedOrigins = ["http://localhost:3000", "https://bodybuddy-umber.vercel.app/"];
+const allowedOrigins = ["http://localhost:3000", "https://bodybuddy-umber.vercel.app"];
 app.use(
   cors({
     origin: (origin, callback) => {


### PR DESCRIPTION
This pull request includes a small change to the `server.js` file. The change modifies the `allowedOrigins` array to remove the trailing slash from one of the URLs.

* [`server/server.js`](diffhunk://#diff-8cf1ffe3788af127768748703e2f15dcfb3a05ffd20b4c2375223637e3260938L20-R20): Removed the trailing slash from the URL "https://bodybuddy-umber.vercel.app/" in the `allowedOrigins` array.