### PR TITLE
Bugfix: Vercel deployment

### DIFF
--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -28,7 +28,7 @@ router.post("/set-cookie", (req, res) => {
   res.cookie("access_token", access_token, {
     httpOnly: true, // Can't be accessed using JavaScript
     secure: process.env.NODE_ENV === "production",
-    sameSite: "None",
+    sameSite: process.env.NODE_ENV === "production" ? "None" : "Strict",
     maxAge: 60 * 60 * 1000, // 60 minutes
   });
   res.status(200).json({ message: "Accesstoken set in HttpOnly cookie" });
@@ -40,7 +40,7 @@ router.post("/clear-cookie", (req, res) => {
   res.clearCookie("access_token", {
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",
-    sameSite: "None",
+    sameSite: process.env.NODE_ENV === "production" ? "None" : "Strict",
   });
   res.status(200).json({ message: "Logged out and cookie cleared" });
 });

--- a/server/server.js
+++ b/server/server.js
@@ -4,9 +4,8 @@ import dotenv from "dotenv";
 import swaggerSetup from "./swagger.js";
 import routes from "./routes/index.js";
 import cookieParser from "cookie-parser";
-import { Buffer } from "buffer";
-
-global.Buffer = Buffer;
+// import { Buffer } from "buffer";
+// global.Buffer = Buffer;
 
 dotenv.config();
 
@@ -17,11 +16,14 @@ swaggerSetup(app);
 
 app.use(express.json());
 
-const allowedOrigins = ["http://localhost:3000", "https://bodybuddy-umber.vercel.app"];
+// const allowedOrigins = ["http://localhost:3000", "https://bodybuddy-umber.vercel.app"];
+const allowedOrigins = ["http://localhost:3000", /^https:\/\/bodybuddy.*\.vercel\.app$/];
 app.use(
   cors({
     origin: (origin, callback) => {
-      if (!origin || allowedOrigins.includes(origin)) {
+      if (!origin || allowedOrigins.some((allowed) =>
+        typeof allowed === "string" ? allowed === origin : allowed.test(origin)
+      )) {
         callback(null, true);
       } else {
         callback(new Error("Not allowed by CORS"));


### PR DESCRIPTION
This pull request includes changes to improve cookie handling and CORS configuration in the server. The most important changes include making the `sameSite` attribute conditional based on the environment, modifying the allowed origins for CORS, and commenting out unused code related to the `Buffer` global.

Improvements to cookie handling:

* [`server/routes/index.js`](diffhunk://#diff-d347091b60673886a3f7f9f7eaf7e970812f0fc22217d00b234df8266f46199dL31-R31): Updated the `sameSite` attribute for cookies to be conditional based on the environment (`production` or not) in the `set-cookie` and `clear-cookie` routes. [[1]](diffhunk://#diff-d347091b60673886a3f7f9f7eaf7e970812f0fc22217d00b234df8266f46199dL31-R31) [[2]](diffhunk://#diff-d347091b60673886a3f7f9f7eaf7e970812f0fc22217d00b234df8266f46199dL43-R43)

Improvements to CORS configuration:

* [`server/server.js`](diffhunk://#diff-8cf1ffe3788af127768748703e2f15dcfb3a05ffd20b4c2375223637e3260938L20-R26): Modified the `allowedOrigins` array to use a regular expression for more flexible matching of subdomains in the `vercel.app` domain.

Code cleanup:

* [`server/server.js`](diffhunk://#diff-8cf1ffe3788af127768748703e2f15dcfb3a05ffd20b4c2375223637e3260938L7-R8): Commented out the import and global assignment of `Buffer` as it is not being used.