### PR TITLE
Extend default timeout duration

### DIFF
--- a/server/vercel.json
+++ b/server/vercel.json
@@ -11,5 +11,10 @@
       "src": "/(.*)",
       "dest": "server.js"
     }
-  ]
+  ],
+  "functions": {
+    "controllers/openaiController.js": {
+      "maxDuration": 60
+    }
+  }
 }


### PR DESCRIPTION
This pull request includes a change to the `server/vercel.json` file to configure the deployment settings for the server. The most important change is the addition of a new `functions` property to specify the maximum duration for the `openaiController.js` function.

Deployment configuration:

* [`server/vercel.json`](diffhunk://#diff-f40656d66e7808f04227df45fafe2e35b0a94d62ce469ef7342e8a456906160eL14-R19): Added a `functions` property to set the maximum duration for `controllers/openaiController.js` to 60 seconds.