### PR TITLE
Add sckelton to premade routine tab

### DIFF
--- a/app/src/pages/TrainingProgram.jsx
+++ b/app/src/pages/TrainingProgram.jsx
@@ -207,7 +207,37 @@ export const TrainingProgram = memo((props) => {
           )
         ) : null}
         {/* PREMADE ROUTINES TAB */}
-        {activeTab === 1 && premadeRoutinesTabContent}
+        {activeTab === 1 ? (
+          loadingPremadeRoutines ? (
+            <>
+              <Grid2 container spacing={3} sx={{width: "100%"}}>
+                <Box flexGrow={1}>
+                  <Skeleton
+                    variant="rectangular"
+                    animation="wave"
+                    height={489}
+                  />
+                </Box>
+                <Box flexGrow={1}>
+                  <Skeleton
+                    variant="rectangular"
+                    animation="wave"
+                    height={489}
+                  />
+                </Box>
+                <Box flexGrow={1}>
+                  <Skeleton
+                    variant="rectangular"
+                    animation="wave"
+                    height={489}
+                  />
+                </Box>
+              </Grid2>
+            </>
+          ) : (
+            premadeRoutinesTabContent
+          )
+        ) : null}
       </Box>
     </>
   );


### PR DESCRIPTION
This pull request includes an enhancement to the user experience by adding a loading skeleton to the `TrainingProgram` component in the `app/src/pages/TrainingProgram.jsx` file. This change ensures that users see a visual loading indicator while the premade routines are being fetched.

Enhancements to user experience:

* [`app/src/pages/TrainingProgram.jsx`](diffhunk://#diff-84b98b6d075b21f08b6cb4215bb409b658142cdc4f3a2f813c2635accfb6cc16L210-R240): Added a loading skeleton to the premade routines tab to visually indicate loading state when `loadingPremadeRoutines` is true.