### PR TITLE
Updated cookie setting

### DIFF
--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -32,7 +32,7 @@ router.post("/set-cookie", (req, res) => {
     secure: process.env.NODE_ENV === "production",
     sameSite: process.env.NODE_ENV === "production" ? "None" : "Strict",
     maxAge: 60 * 60 * 1000, // 60 minutes
-    domain: 'bodybuddy.me'
+    domain: 'www.bodybuddy.me'
   });
   res.status(200).json({ message: "Accesstoken set in HttpOnly cookie" });
 });


### PR DESCRIPTION
This pull request includes a small but important change to the `server/routes/index.js` file. The change modifies the domain for setting cookies to ensure compatibility with the website's subdomain.

* [`server/routes/index.js`](diffhunk://#diff-d347091b60673886a3f7f9f7eaf7e970812f0fc22217d00b234df8266f46199dL35-R35): Changed the `domain` property in the cookie settings from `'bodybuddy.me'` to `'www.bodybuddy.me'` to ensure the cookie is correctly set for the subdomain.