### PR TITLE
Update cookie setting

### DIFF
--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -32,7 +32,7 @@ router.post("/set-cookie", (req, res) => {
     secure: process.env.NODE_ENV === "production",
     sameSite: process.env.NODE_ENV === "production" ? "None" : "Strict",
     maxAge: 60 * 60 * 1000, // 60 minutes
-    domain: 'www.bodybuddy.me'
+    // domain: 'www.bodybuddy.me'
   });
   res.status(200).json({ message: "Accesstoken set in HttpOnly cookie" });
 });


### PR DESCRIPTION
This pull request includes a small change to the `server/routes/index.js` file. The change comments out the `domain` attribute in the cookie settings for the `/set-cookie` route.

* [`server/routes/index.js`](diffhunk://#diff-d347091b60673886a3f7f9f7eaf7e970812f0fc22217d00b234df8266f46199dL35-R35): Commented out the `domain` attribute in the cookie settings for the `/set-cookie` route.