### PR TITLE
Bugfix: Dashboard screen size for mobile

### DIFF
--- a/app/src/components/GadgetHistory.jsx
+++ b/app/src/components/GadgetHistory.jsx
@@ -138,6 +138,9 @@ export const GadgetHistory = ({ history = [] }) => {
     };
     window.addEventListener("resize", handleResize);
 
+    // Initial resize
+    handleResize();
+
     return () => {
       window.removeEventListener("resize", handleResize);
     };


### PR DESCRIPTION
This pull request includes a small change to the `GadgetHistory` component in the `app/src/components/GadgetHistory.jsx` file. The change ensures that the `handleResize` function is called initially to set the correct dimensions when the component is first rendered.

* [`app/src/components/GadgetHistory.jsx`](diffhunk://#diff-66b0245ff01e544a0b9bdeabfcc7013404b139b1f9c2e7ba3058d716bcb831a0R141-R143): Added a call to `handleResize` after setting up the resize event listener to ensure the initial dimensions are set correctly.