### PR TITLE
Extends time-out duration

### DIFF
--- a/server/controllers/openaiController.js
+++ b/server/controllers/openaiController.js
@@ -1,3 +1,4 @@
+export const maxDuration = 60;
 import { OpenAI } from "openai";
 import Groq from "groq-sdk";
 import generateDemoData from "../utils/generateDemoData.js";


### PR DESCRIPTION
This pull request includes a change to the `server/controllers/openaiController.js` file to define a new constant for maximum duration.

* [`server/controllers/openaiController.js`](diffhunk://#diff-e45e057cb383dec98518af61e367ba47cd794b4b2b8f78e3f8f85da09da9d292R1): Added a new constant `maxDuration` set to 60.