### PR TITLE
Extends time-out duration

### DIFF
--- a/server/controllers/openaiController.js
+++ b/server/controllers/openaiController.js
@@ -1,4 +1,6 @@
 export const maxDuration = 60;
+export const dynamic = "force-dynamic";
+
 import { OpenAI } from "openai";
 import Groq from "groq-sdk";
 import generateDemoData from "../utils/generateDemoData.js";


### PR DESCRIPTION
This pull request includes a small change to the `server/controllers/openaiController.js` file. The change adds a new export for a constant named `dynamic` with the value `"force-dynamic"`.

* [`server/controllers/openaiController.js`](diffhunk://#diff-e45e057cb383dec98518af61e367ba47cd794b4b2b8f78e3f8f85da09da9d292R2-R3): Added a new export for `dynamic` with the value `"force-dynamic"`.