### PR TITLE
Revert vercel timeout setting (because that cause another error)

### DIFF
--- a/app/src/pages/TrainingProgram.jsx
+++ b/app/src/pages/TrainingProgram.jsx
@@ -40,6 +40,7 @@ export const TrainingProgram = memo((props) => {
   const [loadingPremadeRoutines, setLoadingPremadeRoutines] = useState(true);
   const [generating, setGenerating] = useState(false);
   const [generatingComplete, setGeneratingComplete] = useState(false);
+  const [promptReady, setPromptReady] = useState(false);
   const prompt = useGenerateProgramPrompt({});
   const navigate = useNavigate();
 
@@ -52,6 +53,13 @@ export const TrainingProgram = memo((props) => {
     setPageTitle(props.title);
     loadData();
   }, []);
+
+  // Check if prompt is ready
+  useEffect(() => {
+    if (prompt) {
+      setPromptReady(true);
+    }
+  }, [prompt]);
 
   // Generate a new personalized program for the user
   useEffect(() => {
@@ -164,7 +172,7 @@ export const TrainingProgram = memo((props) => {
     <>
       {/* Backdrop for loading */}
       {activeTab === 0 && (
-        <LoadingBackdrop loading={loadingProgram} generating={generating} />
+        <LoadingBackdrop loading={loadingProgram || !promptReady} generating={generating} />
       )}
       {activeTab === 1 && <LoadingBackdrop loading={loadingPremadeRoutines} />}
 

--- a/server/controllers/openaiController.js
+++ b/server/controllers/openaiController.js
@@ -1,5 +1,6 @@
-export const maxDuration = 60;
-export const dynamic = "force-dynamic";
+// THE FOLLOWING CODE FOR VERCEL TIMEOUT ADJUSTMENT BUT CAUSE THE ERROR:
+// export const maxDuration = 60;
+// export const dynamic = "force-dynamic";
 
 import { OpenAI } from "openai";
 import Groq from "groq-sdk";

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,5 +1,6 @@
-export const maxDuration = 60;
-export const dynamic = "force-dynamic";
+// THE FOLLOWING CODE FOR VERCEL TIMEOUT ADJUSTMENT BUT CAUSE THE ERROR:
+// export const maxDuration = 60;
+// export const dynamic = "force-dynamic";
 
 import express from "express";
 import userRoutes from "./userRoutes.js";


### PR DESCRIPTION
This pull request includes changes to the `TrainingProgram` component in `app/src/pages/TrainingProgram.jsx` to improve the loading logic and updates to the server configuration to address a Vercel timeout issue.

Improvements to `TrainingProgram` component:

* Added `promptReady` state to track if the prompt is ready for generating a personalized program.
* Added a `useEffect` hook to set `promptReady` to `true` when the prompt is available.
* Updated `LoadingBackdrop` to consider `promptReady` state to ensure proper loading indication.

Server configuration updates:

* Commented out `maxDuration` and `dynamic` exports in `server/controllers/openaiController.js` due to errors caused by Vercel timeout adjustments.
* Commented out `maxDuration` and `dynamic` exports in `server/routes/index.js` for the same reason.