### PR TITLE
Adds cache-control header

### DIFF
--- a/app/src/utils/AuthProvider.jsx
+++ b/app/src/utils/AuthProvider.jsx
@@ -96,6 +96,16 @@ export function AuthProvider({ children }) {
   const handleSignOut = async () => {
     // Sign out from supabase autehtication
     try {
+      // Check if there is an active session
+      const { data: session, error: sessionError } = await supabase.auth.getSession();
+      if (sessionError || !session) {
+        console.log("No active session found. Clearing user state.");
+        setUser(null);
+        window.localStorage.clear();
+        return;
+      }
+
+      // Sign out the user
       const { error } = await supabase.auth.signOut();
       if (error) {
         throw error;
@@ -104,6 +114,8 @@ export function AuthProvider({ children }) {
       setUser(null);
     } catch (error) {
       console.log("User failed to sign out", error);
+      setUser(null);
+      window.localStorage.clear();
       return;
     }
   };

--- a/server/controllers/exerciseController.js
+++ b/server/controllers/exerciseController.js
@@ -12,6 +12,7 @@ export const getExercises = async (req, res) => {
         offset: offset,
         limit: limit,
       });
+      res.set("Cache-Control", "public, max-age=3600");
       res.status(200).json({
         status: "200",
         message: "Success",
@@ -85,6 +86,7 @@ export const getExerciseTypes = async (req, res) => {
         exercise_id: exercise_id,
       },
     });
+    res.set("Cache-Control", "public, max-age=3600");
     res.status(200).json({
       status: "200",
       message: "Success",
@@ -106,6 +108,7 @@ export const getExerciseGoals = async (req, res) => {
         exercise_id: exercise_id,
       },
     });
+    res.set("Cache-Control", "public, max-age=3600");
     res.status(200).json({
       status: "200",
       message: "Success",
@@ -127,6 +130,7 @@ export const getExerciseMuscleGroups = async (req, res) => {
         exercise_id: exercise_id,
       },
     });
+    res.set("Cache-Control", "public, max-age=3600");
     res.status(200).json({
       status: "200",
       message: "Success",
@@ -162,7 +166,6 @@ export const createExercise = async (req, res) => {
     });
   }
 };
-
 export const updateExercise = async (req, res) => {
   try {
     const { id } = req.params;
@@ -190,7 +193,6 @@ export const updateExercise = async (req, res) => {
     });
   }
 };
-
 export const deleteExercise = async (req, res) => {
   try {
     const { id } = req.params;

--- a/server/controllers/localTablesController.js
+++ b/server/controllers/localTablesController.js
@@ -7,6 +7,7 @@ import Type from "../models/Type.js";
 export const getIntensities = async (req, res) => {
   try {
     const IntensityList = await Intensity.findAll();
+    res.set("Cache-Control", "public, max-age=3600");
     res.status(200).json({
       status: "200",
       message: "Success",
@@ -20,7 +21,6 @@ export const getIntensities = async (req, res) => {
     });
   }
 };
-
 export const getIntensity = async (req, res) => {
   try {
     const intensity_id = req.params.intensity_id;
@@ -31,6 +31,7 @@ export const getIntensity = async (req, res) => {
         message: "Intensity not found",
       });
     }
+    res.set("Cache-Control", "public, max-age=3600");
     res.status(200).json({
       status: "200",
       message: "Success",
@@ -53,6 +54,7 @@ export const getGoals = async (req, res) => {
         message: "Goals not found",
       });
     }
+    res.set("Cache-Control", "public, max-age=3600");
     res.status(200).json({
       status: "200",
       message: "Success",
@@ -76,6 +78,7 @@ export const getGoal = async (req, res) => {
         message: "Goal not found",
       });
     }
+    res.set("Cache-Control", "public, max-age=3600");
     res.status(200).json({
       status: "200",
       message: "Success",
@@ -143,6 +146,7 @@ export const getMuscleGroups = async (req, res) => {
         message: "MuscleGroups not found",
       });
     }
+    res.set("Cache-Control", "public, max-age=3600");
     res.status(200).json({
       status: "200",
       message: "Success",
@@ -166,6 +170,7 @@ export const getMuscleGroup = async (req, res) => {
         message: "MuscleGroup not found",
       });
     }
+    res.set("Cache-Control", "public, max-age=3600");
     res.status(200).json({
       status: "200",
       message: "Success",
@@ -179,7 +184,6 @@ export const getMuscleGroup = async (req, res) => {
     });
   }
 };
-
 export const getTypes = async (req, res) => {
   try {
     const types = await Type.findAll();
@@ -189,6 +193,7 @@ export const getTypes = async (req, res) => {
         message: "Types not found",
       });
     }
+    res.set("Cache-Control", "public, max-age=3600");
     res.status(200).json({
       status: "200",
       message: "Success",
@@ -212,6 +217,7 @@ export const getType = async (req, res) => {
         message: "Type not found",
       });
     }
+    res.set("Cache-Control", "public, max-age=3600");
     res.status(200).json({
       status: "200",
       message: "Success",

--- a/server/utils/generateDemoData.js
+++ b/server/utils/generateDemoData.js
@@ -34,6 +34,7 @@ const generateDemoData = async () => {
 
   data.routine = data.routine.map((r) => ({
     ...r,
+    program_id: generateNewUUID(r.program_id),
     id: generateNewUUID(r.id),
   }));
 


### PR DESCRIPTION
This pull request includes changes to improve user sign-out handling and add cache control headers to various API responses. The most important changes include enhancements to the `AuthProvider` component and the addition of cache control headers in multiple controller functions.

Improvements to user sign-out handling:

* [`app/src/utils/AuthProvider.jsx`](diffhunk://#diff-e3516a9b0bc18538edb87dac194721a74f64e63dce21b8dae9310e8d2cd752fbR99-R108): Added a check for an active session before signing out the user, and ensured that user state and local storage are cleared in case of errors during sign-out. [[1]](diffhunk://#diff-e3516a9b0bc18538edb87dac194721a74f64e63dce21b8dae9310e8d2cd752fbR99-R108) [[2]](diffhunk://#diff-e3516a9b0bc18538edb87dac194721a74f64e63dce21b8dae9310e8d2cd752fbR117-R118)

Addition of cache control headers:

* [`server/controllers/exerciseController.js`](diffhunk://#diff-c8323713d0d1eff48bd40bd034c459d01d5bb13c14bb95cd222509b81b21fe3cR15): Added `Cache-Control` headers to the responses of `getExercises`, `getExerciseTypes`, `getExerciseGoals`, and `getExerciseMuscleGroups` functions to improve caching. [[1]](diffhunk://#diff-c8323713d0d1eff48bd40bd034c459d01d5bb13c14bb95cd222509b81b21fe3cR15) [[2]](diffhunk://#diff-c8323713d0d1eff48bd40bd034c459d01d5bb13c14bb95cd222509b81b21fe3cR89) [[3]](diffhunk://#diff-c8323713d0d1eff48bd40bd034c459d01d5bb13c14bb95cd222509b81b21fe3cR111) [[4]](diffhunk://#diff-c8323713d0d1eff48bd40bd034c459d01d5bb13c14bb95cd222509b81b21fe3cR133)
* [`server/controllers/localTablesController.js`](diffhunk://#diff-0792c371c6ab332fea871d5faaac4d99300ead8e8e73e0c8d540511873d3229aR10): Added `Cache-Control` headers to the responses of `getIntensities`, `getIntensity`, `getGoals`, `getGoal`, `getMuscleGroups`, `getMuscleGroup`, `getTypes`, and `getType` functions to improve caching. [[1]](diffhunk://#diff-0792c371c6ab332fea871d5faaac4d99300ead8e8e73e0c8d540511873d3229aR10) [[2]](diffhunk://#diff-0792c371c6ab332fea871d5faaac4d99300ead8e8e73e0c8d540511873d3229aR34) [[3]](diffhunk://#diff-0792c371c6ab332fea871d5faaac4d99300ead8e8e73e0c8d540511873d3229aR57) [[4]](diffhunk://#diff-0792c371c6ab332fea871d5faaac4d99300ead8e8e73e0c8d540511873d3229aR81) [[5]](diffhunk://#diff-0792c371c6ab332fea871d5faaac4d99300ead8e8e73e0c8d540511873d3229aR149) [[6]](diffhunk://#diff-0792c371c6ab332fea871d5faaac4d99300ead8e8e73e0c8d540511873d3229aR173) [[7]](diffhunk://#diff-0792c371c6ab332fea871d5faaac4d99300ead8e8e73e0c8d540511873d3229aR196) [[8]](diffhunk://#diff-0792c371c6ab332fea871d5faaac4d99300ead8e8e73e0c8d540511873d3229aR220)

Additional changes:

* [`server/utils/generateDemoData.js`](diffhunk://#diff-b8a5cba34a403a7d8d5b5b6b484fcb3a029dc3df42af3b6724d3d6af2bb47c67R37): Updated the `generateDemoData` function to generate new UUIDs for `program_id` in the routine data.