### PR TITLE
Bugfix: date of demo data (UTC => PST)

### DIFF
--- a/server/utils/generateDemoData.js
+++ b/server/utils/generateDemoData.js
@@ -1,12 +1,17 @@
 import { v4 as uuidv4 } from 'uuid';
+import { format } from 'date-fns';
+import { toZonedTime } from 'date-fns-tz';
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const generateDemoData = async () => {
   const uuidMap = {};
   const today = new Date();
+  const timeZone = 'America/Vancouver';
+
   let scheduleDate = new Date(today);
   scheduleDate.setHours(0, 0, 0, 0); // Reset time to 00:00:00
+  const zonedDate = toZonedTime(scheduleDate, timeZone);
 
   // Sleep 5 seconds
   await sleep(5000);
@@ -27,7 +32,7 @@ const generateDemoData = async () => {
   }));
   data.program_routine = data.program_routine.map((routine) => {
     const updatedRoutine = { ...routine };
-    updatedRoutine.scheduled_date = scheduleDate.toISOString().split('T')[0]; // YYYY-MM-DD
+    updatedRoutine.scheduled_date = format(zonedDate, 'yyyy-MM-dd');
     scheduleDate.setDate(scheduleDate.getDate() + 2);
     return updatedRoutine;
   });


### PR DESCRIPTION
This pull request includes changes to the `generateDemoData` function in `server/utils/generateDemoData.js` to handle time zones more accurately. The most important changes include importing new functions from `date-fns` and `date-fns-tz`, and updating the date formatting to use these functions.

Time zone handling improvements:

* [`server/utils/generateDemoData.js`](diffhunk://#diff-b8a5cba34a403a7d8d5b5b6b484fcb3a029dc3df42af3b6724d3d6af2bb47c67R2-R14): Imported `format` from `date-fns` and `toZonedTime` from `date-fns-tz` to handle time zones accurately.
* [`server/utils/generateDemoData.js`](diffhunk://#diff-b8a5cba34a403a7d8d5b5b6b484fcb3a029dc3df42af3b6724d3d6af2bb47c67L30-R35): Updated the `generateDemoData` function to use `toZonedTime` for converting the schedule date to the specified time zone and `format` for formatting the date.