### PR TITLE
Make unavailable "Jumping Jacks" coz its logic is not ready enough

### DIFF
--- a/app/src/utils/motionDetectLogic/exerciseCounterLoader.js
+++ b/app/src/utils/motionDetectLogic/exerciseCounterLoader.js
@@ -1,10 +1,10 @@
 import { SquatCounter } from './squatCounter';
 import { PushupCounter } from './pushupCounter';
-import { JumpingJacksCounter } from './jumpingJacksCounter';
+// import { JumpingJacksCounter } from './jumpingJacksCounter';
 
 export const exerciseCounterLoader = {
   // Specify the exercuse ID and the corresponding counter class
   "ed999b28-ae50-4009-b29c-c7f6a28857c9" : PushupCounter,
   "fb7180ab-f3e2-4a5d-b731-a2c0fc5de9fa" : SquatCounter,
-  "0cc22f75-7d4d-4d50-9cdd-4ae3c731c517" : JumpingJacksCounter,
+  // "0cc22f75-7d4d-4d50-9cdd-4ae3c731c517" : JumpingJacksCounter,
 };


### PR DESCRIPTION
This pull request includes a minor change to the `exerciseCounterLoader` in the `motionDetectLogic` utilities. The change comments out the import and usage of the `JumpingJacksCounter` class.

Changes to `exerciseCounterLoader`:

* [`app/src/utils/motionDetectLogic/exerciseCounterLoader.js`](diffhunk://#diff-3c1b041e6eb5f237a129a77391ddf011495fb42b26293d0b83e6c6df217a284dL3-R9): Commented out the import statement and the usage of `JumpingJacksCounter` in the `exerciseCounterLoader` object.